### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're building production-ready NLP and LLM pipelines with Haystack using strict tool contracts, and orchestrating context-aware, observable RAG and agentic workflows with LangGraph for scalable, customizable AI applications. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.


1. [HIGH] LangChain tool fetches a caller-controlled URL (SSRF)
   File: ch8/yelp-navigator/langgraph_helpers/tools.py
   What it means: This LangChain tool issues an HTTP request whose URL is built from a parameter or interpolated value rather than a fixed literal.

2. [HIGH] LangChain tool fetches a caller-controlled URL (SSRF)
   File: ch8/yelp-navigator/langgraph_helpers/tools.py
   What it means: This LangChain tool issues an HTTP request whose URL is built from a parameter or interpolated value rather than a fixed literal.

3. [HIGH] LangChain tool fetches a caller-controlled URL (SSRF)
   File: ch8/yelp-navigator/langgraph_helpers/tools.py
   What it means: This LangChain tool issues an HTTP request whose URL is built from a parameter or interpolated value rather than a fixed literal.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)